### PR TITLE
It should be a verb, not a noun for method name

### DIFF
--- a/TULJava/ex_6/Registry.java
+++ b/TULJava/ex_6/Registry.java
@@ -2,6 +2,6 @@ package task;
 
 public  abstract class Registry
 {
-	public abstract void description();
+	public abstract void showDescription();
 	public abstract fullNumber getPhoneNumber();
 }


### PR DESCRIPTION
It should be a verb, not a noun for method name